### PR TITLE
Cam port

### DIFF
--- a/TGIT.sh
+++ b/TGIT.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Test for bad git repo
+# Ensures that the top-level CAM directory 
+# has ".git" directory and ".gitignore" file,
+# and no other git files or directories.
+
+# Return codes in use:
+# 1: Not a git repository.
+# 2: Missing ".git" directory.
+# 3: Missing ".gitignore" file.
+# 4: More than two ".git*" files.
+# 5: Error from running an external command
+
+# Utility to check return code.
+# Give it the code and an error message, and it will print stuff and exit.
+check_code () {
+    if [ "$1" -ne 0 ]; then
+        echo "Error: return code from command was $1"
+        echo "$2"
+        exit 5
+    fi
+}
+
+# Little utility for finding absolute path to a directory.
+get_dir_abspath () {
+    echo $(cd $1 && pwd)
+}
+
+# Set CAM top-level directory:
+cam_top_dir=$(get_dir_abspath ${CAM_SCRIPTDIR}/../..)
+
+# Initialize error variable:
+rc=0
+
+# Check to make sure that the top level directory is a git repo:
+top_dir_gitinfo=$(git -C "${cam_top_dir}" rev-parse)
+
+# Save error code:
+gitinfo_error=$?
+
+# Print error if directory is not a git repository:
+if [ "${gitinfo_error}" -ne 0 ]; then
+    cat <<EOF
+The top directory does not appear to be a git repository. Make sure:
+1) Git is present on your system and PATH (i.e. "git" exists as a command in your shell).
+2) You are running these tests on the correct directory, and
+3) The sub-directory ".git" exists in the directory (if not then copy it from a proper CAM git repo).
+EOF
+    rc=1
+else # If directory is a git repoistory, then run other tests:
+
+    # Check for ".git" directory (i.e., make sure git repo isn't "bare"):
+    if [ ! -d "${cam_top_dir}/.git" ]; then
+        cat <<EOF
+The ".git" directory is missing from the CAM git repo.  Was this repo cloned, copied, or
+modified incorrectly?  If so then copy the .git directory from a standard CAM git repo.
+EOF
+        rc=2
+    fi
+
+    # Check for missing ".gitignore" file.
+    if [ ! -f "${cam_top_dir}/.gitignore" ]; then
+        cat <<EOF
+The ".gitignore" file is missing from the CAM git repo.  Was this repo cloned, copied, or
+modified incorrectly?  If so then copy the .gitignore file from a standard CAM git repo.
+EOF
+        rc=3
+    fi   
+
+    # Check if there are more ".git*" files or directories than just ".git" or ".gitignore".
+    git_file_num=$(find "${cam_top_dir}" -maxdepth 1 -name '.git*' | wc -l)
+
+    check_code "$?" "Problem running 'find' command for multi-git file check."
+
+    if [ "${git_file_num}" -gt 2 ]; then
+        cat <<EOF
+More than two ".git*" files or sub-directories present in this CAM git repo.
+EOF
+        rc=4
+    fi
+
+fi # git-repo check
+
+# If all tests pass, let user know:
+if [ "$rc" -eq 0 ]; then
+    echo "No problems found in the git repostiory ($cam_top_dir)."
+fi
+
+# Exit script with final error value:
+exit $rc

--- a/svn_select_to_git.py
+++ b/svn_select_to_git.py
@@ -244,7 +244,11 @@ def cam_svn_to_git_mods(repo_dir):
     file_sub_text(filename, patterns)
     # buildcpp
     filename = os.path.join(cconfig, 'buildcpp')
-    patterns = {'"components", "cam", ' : ''}
+    patterns = {'cmd = os.path.join\(srcroot, "components", "cam", "bld", "configure"\) \+ \\\\' :
+               ('testpath = os.path.join(srcroot, "components", "cam")'
+                '\n    if os.path.exists(testpath):'
+                '\n        srcroot = testpath\n'
+                r'    cmd = os.path.join(srcroot, "bld", "configure") + \\')}
     file_sub_text(filename, patterns)
     num_changes += 1
     # config_files/definition.xml

--- a/svn_select_to_git.py
+++ b/svn_select_to_git.py
@@ -311,14 +311,14 @@ def cam_svn_to_git_mods(repo_dir):
                 '    fi\n'),
 
                 'export CAM_ROOT=\\\`cd \\\\\$\{CAM_SCRIPTDIR}(/\.\.){4} ; pwd \\\`' :
-               ('if [ -d \`${CAM_SCRIPTDIR}/../../components\` ]; then\n'
+               ('if [ -d "\${CAM_SCRIPTDIR}/../../components" ]; then\n'
                 '        export CAM_ROOT=\`cd \${CAM_SCRIPTDIR}/../.. ; pwd \`\n'
                 '    else\n'
                 '        export CAM_ROOT=\`cd \${CAM_SCRIPTDIR}/../../../.. ; pwd \`\n'
                 '    fi'),
 
                 'echo \"ERROR: unable to determine script directory \"' :
-               ('if [ -n "\${CAM_ROOT}" ] && [ -f \${CAM_ROOT}/test/system/test_driver.sh ]; then\n'
+               ('if [ -n "\${CAM_ROOT}"  -a  -f "\${CAM_ROOT}/test/system/test_driver.sh" ]; then\n'
                 '            export CAM_SCRIPTDIR=\`cd \${CAM_ROOT}/test/system; pwd \`\n'
                 '        else\n'
                 '            echo \"ERROR: unable to determine script directory \"'),

--- a/svn_select_to_git.py
+++ b/svn_select_to_git.py
@@ -16,7 +16,7 @@ thisFile = os.path.realpath(inspect.getfile(inspect.currentframe()))
 currDir = os.path.dirname(thisFile)
 
 ## Boilerplate files
-cam_copy_files = [".config_files.xml", ".gitignore"]
+cam_copy_files = [".config_files.xml", ".gitignore", "TGIT.sh"]
 
 ## Regular expression for source files
 cby_str="Committed by"
@@ -514,6 +514,25 @@ def cam_svn_to_git_mods(repo_dir):
                 'exit $rc')}
     file_sub_text(filename, patterns)    
     num_changes += 1
+    #input_tests_master
+    filename = os.path.join(systest, 'input_tests_master')
+    patterns = {'fm001 TFM.sh' :
+               ('gt001 TGIT.sh\n'
+                'fm001 TFM.sh')}
+    file_sub_text(filename, patterns)
+    num_changes += 1
+    #tests_pretag_hobart_nag
+    filename = os.path.join(systest, 'tests_pretag_hobart_nag')
+    patterns = {'fm001' : 'gt001'}
+    file_sub_text(filename, patterns)
+    num_changes += 1
+    #tests_pretag_izumi_nag
+    filename = os.path.join(systest, 'tests_pretag_izumi_nag')
+    #check that file actually exists (it doesn't always for older CAM versions):
+    if os.path.exists(filename):  
+        patterns = {'fm001' : 'gt001'}
+        file_sub_text(filename, patterns)
+        num_changes += 1
     #Makefile.in
     filename = os.path.join(bld, 'Makefile.in') 
     patterns = {'\$\(ROOTDIR\)/components/cam/bld/mkDepends Filepath Srcfiles > \$@' :
@@ -1450,8 +1469,13 @@ def processRevision(export_dir, git_dir, log, external, cam_move):
     # Add boilerplate files
     #--------------------------------------
     for file in cam_copy_files:
-        src_path = os.path.join(currDir, "cam{}".format(file))
-        dst_path = os.path.join(git_dir, file)
+        if file == "TGIT.sh":
+            src_path = os.path.join(currDir,file)
+            dst_path = os.path.join(git_dir, "test", "system", file)
+        else:
+            src_path = os.path.join(currDir, "cam{}".format(file))
+            dst_path = os.path.join(git_dir, file)
+
         needs_add = not os.path.exists(dst_path)
         if file_diff(src_path, dst_path):
             shutil.copy2(src_path, dst_path)


### PR DESCRIPTION
Added modifications to allow for CESM and regression script builds in git.  I should note that I had to revert one of your changes to "configure" in order to get the regression scripts to work.  Also some of the white-spacing in the modified scripts can turn out a little wonky, but the code itself should be fine. 

Python script tests run for latest commit:

./svn_select_to_git.py --author-table CAM_name_table.txt --tags https://svn-ccsm-models.cgd.ucar.edu/cam1/trunk_tags --rev 91300:91422 cam_trunk_svn ../cam_trunk_git https://svn-ccsm-models.cgd.ucar.edu/cam1/trunk

test/cam_test.sh

CAM tests run for latest commit:

"test/system/test_driver.sh -f" on izumi, with cam6_1_027 tag, with NAG compiler, in CAM-only framework.

"test/system/test_driver.sh -f" on hobart, with cam_cesm2_1_rel_26 tag, with NAG compiler, in CESM framework.

Also ran "test_drivers.sh -f" with ".git" removed, ".gitignore" removed, an extra ".git" file added, and in a subversion repository, to ensure that the "TGIT.sh" script behaves as expected.